### PR TITLE
task: improve responsive layout

### DIFF
--- a/themes/aoepeople.github.io/assets/dist/main.css
+++ b/themes/aoepeople.github.io/assets/dist/main.css
@@ -961,19 +961,14 @@ h2 {
   margin-bottom: 5rem;
 }
 
-.my-12 {
-  margin-top: 3rem;
-  margin-bottom: 3rem;
+.mx-2 {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
 }
 
-.mx-4 {
-  margin-left: 1rem;
-  margin-right: 1rem;
-}
-
-.my-4 {
-  margin-top: 1rem;
-  margin-bottom: 1rem;
+.my-8 {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
 }
 
 .mt-8 {
@@ -984,16 +979,8 @@ h2 {
   margin-top: 1rem;
 }
 
-.mr-8 {
-  margin-right: 2rem;
-}
-
-.mt-3 {
-  margin-top: 0.75rem;
-}
-
-.block {
-  display: block;
+.mb-12 {
+  margin-bottom: 3rem;
 }
 
 .inline-block {
@@ -1020,16 +1007,12 @@ h2 {
   height: 4rem;
 }
 
-.h-10 {
-  height: 2.5rem;
-}
-
 .h-48 {
   height: 12rem;
 }
 
-.h-full {
-  height: 100%;
+.h-10 {
+  height: 2.5rem;
 }
 
 .min-h-screen {
@@ -1048,12 +1031,8 @@ h2 {
   width: 100%;
 }
 
-.w-48 {
-  width: 12rem;
-}
-
-.max-w-md {
-  max-width: 28rem;
+.max-w-4xl {
+  max-width: 56rem;
 }
 
 .flex-grow {
@@ -1064,8 +1043,20 @@ h2 {
   flex-grow: 1;
 }
 
+.basis-1\/6 {
+  flex-basis: 16.666667%;
+}
+
+.basis-5\/6 {
+  flex-basis: 83.333333%;
+}
+
 .grid-cols-1 {
   grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+.flex-row {
+  flex-direction: row;
 }
 
 .flex-col {
@@ -1147,26 +1138,6 @@ h2 {
      object-fit: contain;
 }
 
-.object-cover {
-  -o-object-fit: cover;
-     object-fit: cover;
-}
-
-.object-scale-down {
-  -o-object-fit: scale-down;
-     object-fit: scale-down;
-}
-
-.object-right {
-  -o-object-position: right;
-     object-position: right;
-}
-
-.object-center {
-  -o-object-position: center;
-     object-position: center;
-}
-
 .object-top {
   -o-object-position: top;
      object-position: top;
@@ -1176,17 +1147,9 @@ h2 {
   padding: 1rem;
 }
 
-.p-8 {
-  padding: 2rem;
-}
-
-.p-2 {
-  padding: 0.5rem;
-}
-
-.px-20 {
-  padding-left: 5rem;
-  padding-right: 5rem;
+.px-8 {
+  padding-left: 2rem;
+  padding-right: 2rem;
 }
 
 .py-4 {
@@ -1214,14 +1177,9 @@ h2 {
   padding-right: 0.25rem;
 }
 
-.px-8 {
-  padding-left: 2rem;
-  padding-right: 2rem;
-}
-
-.px-10 {
-  padding-left: 2.5rem;
-  padding-right: 2.5rem;
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .py-8 {
@@ -1229,17 +1187,8 @@ h2 {
   padding-bottom: 2rem;
 }
 
-.px-4 {
-  padding-left: 1rem;
-  padding-right: 1rem;
-}
-
 .pr-4 {
   padding-right: 1rem;
-}
-
-.pt-24 {
-  padding-top: 6rem;
 }
 
 .pt-8 {
@@ -1254,8 +1203,12 @@ h2 {
   padding-top: 0.5rem;
 }
 
-.pb-12 {
-  padding-bottom: 3rem;
+.pl-4 {
+  padding-left: 1rem;
+}
+
+.pb-8 {
+  padding-bottom: 2rem;
 }
 
 .text-center {
@@ -1319,20 +1272,9 @@ h2 {
   color: rgb(107 114 128 / var(--tw-text-opacity));
 }
 
-.underline {
-  -webkit-text-decoration-line: underline;
-          text-decoration-line: underline;
-}
-
 .shadow-2xl {
   --tw-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
   --tw-shadow-colored: 0 25px 50px -12px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-}
-
-.shadow-md {
-  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
@@ -1552,6 +1494,15 @@ h2 {
     margin-bottom: 0;
   }
 
+  .md\:mx-8 {
+    margin-left: 2rem;
+    margin-right: 2rem;
+  }
+
+  .md\:mt-8 {
+    margin-top: 2rem;
+  }
+
   .md\:flex {
     display: flex;
   }
@@ -1560,72 +1511,34 @@ h2 {
     height: 100%;
   }
 
-  .md\:h-48 {
-    height: 12rem;
-  }
-
-  .md\:h-1\/5 {
-    height: 20%;
-  }
-
-  .md\:h-auto {
-    height: auto;
+  .md\:w-1\/3 {
+    width: 33.333333%;
   }
 
   .md\:w-48 {
     width: 12rem;
   }
 
-  .md\:w-full {
-    width: 100%;
-  }
-
-  .md\:w-1\/5 {
-    width: 20%;
-  }
-
-  .md\:w-96 {
-    width: 24rem;
-  }
-
-  .md\:w-1\/3 {
-    width: 33.333333%;
-  }
-
-  .md\:max-w-2xl {
-    max-width: 42rem;
-  }
-
   .md\:shrink-0 {
     flex-shrink: 0;
   }
 
-  .md\:p-8 {
-    padding: 2rem;
+  .md\:px-20 {
+    padding-left: 5rem;
+    padding-right: 5rem;
   }
 
-  .md\:py-8 {
-    padding-top: 2rem;
-    padding-bottom: 2rem;
+  .md\:px-0 {
+    padding-left: 0px;
+    padding-right: 0px;
   }
 
-  .md\:px-8 {
-    padding-left: 2rem;
-    padding-right: 2rem;
-  }
-
-  .md\:py-2 {
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+  .md\:pt-12 {
+    padding-top: 3rem;
   }
 
   .md\:pl-8 {
     padding-left: 2rem;
-  }
-
-  .md\:text-lg {
-    font-size: 1.125rem;
-    line-height: 1.75rem;
   }
 }
 

--- a/themes/aoepeople.github.io/layouts/_default/baseof.html
+++ b/themes/aoepeople.github.io/layouts/_default/baseof.html
@@ -3,9 +3,14 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="viewport">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <title>{{ block "title" . }}{{ with .Params.Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   {{ $style := resources.Get "dist/main.css" | resources.Minify | resources.Fingerprint }}
+  <link rel="apple-touch-icon" sizes="180x180" href="//cdn3.aoe.com/typo3conf/ext/aoeweb_base/Resources/Public/Images/Favicons/aoe/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="//cdn1.aoe.com/typo3conf/ext/aoeweb_base/Resources/Public/Images/Favicons/aoe/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="//cdn2.aoe.com/typo3conf/ext/aoeweb_base/Resources/Public/Images/Favicons/aoe/favicon-16x16.png">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.0/css/all.min.css" rel="stylesheet" as="style">
   <link rel="stylesheet" href="{{ $style.Permalink }}">
 </head>
 
@@ -22,27 +27,47 @@
     </div>
   </div>
 
-  <div class="container mx-auto bg-white pt-24 min-h-screen px-20">
+  <div class="container mx-auto bg-white pt-8 md:pt-12 min-h-screen px-8 md:px-20">
     {{ block "main" . }}{{ end }}
   </div>
 
-  <div class="container my-20 mx-auto">
-    <img src="https://cdn4.aoe.com/typo3conf/ext/aoeweb_base/Resources/Public/Images/Logos/aoe_blue.svg"
-      class="h-10 float-left pr-4" />
-    <div class="text-gray-500 text-sm">
-      AOE is a leading global provider of services for digital transformation and digital business models. AOE relies
-      exclusively on established Enterprise Open Source technologies. This leads to innovative solutions, digital
-      products
-      and portals in agile software projects, and helps build long-lasting, strategic partnerships with our customers.
+  <div class="container my-20 mx-auto px-8 md:px-20">
+    <div class="flex flex-row mx-auto prose lg:prose-xl md:prose-lg">
+      <img src="https://cdn4.aoe.com/typo3conf/ext/aoeweb_base/Resources/Public/Images/Logos/aoe_blue.svg"
+        class="basis-1/6 h-10" />
+      <!--max-w-4xl -->
+      <div class="basis-5/6 text-gray-500 text-sm pl-4">
+        AOE is a leading global provider of services for digital transformation and digital business models. AOE relies
+        exclusively on established Enterprise Open Source technologies. This leads to innovative solutions, digital
+        products
+        and portals in agile software projects, and helps build long-lasting, strategic partnerships with our customers.
+      </div>
     </div>
-    <div class="clear-both pt-8">
-      <a href="https://www.aoe.com/en/imprint.html" class="underline text-gray-500">Legal Information</a>
+    <div class="clear-both pt-8 text-3xl text-blue-900 text-center">
+      <a href="https://www.facebook.com/aoepeople" target="_blank" class="mx-2 md:mx-8" aria-label="Facebook" rel="noreferrer">
+        <span class="fab fa-facebook-f"></span>
+      </a>
+      <a href="https://twitter.com/aoepeople" target="_blank" class="mx-2 md:mx-8" aria-label="Twitter" rel="noreferrer">
+        <span class="fab fa-twitter"></span>
+      </a>
+      <a href="https://www.linkedin.com/company/aoe" target="_blank" class="mx-2 md:mx-8" aria-label="Linkedin" rel="noreferrer">
+        <span class="fab fa-linkedin-in"></span>
+      </a>
+      <a href="https://www.xing.com/company/aoe" target="_blank" class="mx-2 md:mx-8" aria-label="Xing" rel="noreferrer">
+        <span class="fab fa-xing"></span>
+      </a>
+      <a href="https://www.instagram.com/aoepeople" target="_blank" class="mx-2 md:mx-8" aria-label="Instagram" rel="noreferrer">
+        <span class="fab fa-instagram"></span>
+      </a>
+      <a href="https://www.youtube.com/user/aoepeople" target="_blank" class="mx-2 md:mx-8" aria-label="Youtube" rel="noreferrer">
+        <span class="fab fa-youtube"></span>
+      </a>
+      <a href="https://github.com/AOEpeople/" target="_blank" class="mx-2 md:mx-8" aria-label="Github" rel="noreferrer">
+        <span class="fab fa-github"></span>
+      </a>
     </div>
-    <div class="clear-both pt-8">
-      Follow us:
-      <a href="https://www.linkedin.com/company/aoe" class="underline text-gray-500">Linkedin</a>
-      <a href="https://twitter.com/aoepeople" class="underline text-gray-500">Twitter</a>
-      <a href="https://github.com/aoepeople" class="underline text-gray-500">Github</a>
+    <div class="clear-both pt-8 mb-12 text-center text-sm">
+      <a href="https://www.aoe.com/en/imprint.html" class="text-blue-900">Legal Information</a>
     </div>
   </div>
 </body>

--- a/themes/aoepeople.github.io/layouts/_default/single.html
+++ b/themes/aoepeople.github.io/layouts/_default/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div class="pt-8">
   <div>
-    <h2 class="mt-8 py-4 text-center border-b">{{ .Title }}</h2>
+    <h2 class="mt-4 md:mt-8 py-4 text-center border-b">{{ .Title }}</h2>
   </div>
   <div>
     <div class="italic text-gray-600 text-sm">
@@ -9,7 +9,7 @@
     </div>
   </div>
 
-  <div class="my-12 pb-12 mx-auto prose lg:prose-xl md:prose-lg">
+  <div class="my-8 pb-8 mx-auto prose lg:prose-xl md:prose-lg">
     {{ .Content }}
   </div>
 </div>

--- a/themes/aoepeople.github.io/layouts/index.html
+++ b/themes/aoepeople.github.io/layouts/index.html
@@ -9,7 +9,7 @@
       <a class="rounded-xl p-4 flex flex-col shadow-2xl shadow-gray-200 border-b-4 border-gray-100"
         href="{{ .html_url }}">
         <div class="py-2 uppercase text-gray-600 text-sm font-bold">{{ .language }}</div>
-        <div class="text-2xl pb-2"><span class="text-gray-400">AOEpeople/</span><span class="font-bold text-blue-900">{{
+        <div class="text-2xl pb-2"><span class="text-gray-400">AOEpeople/</span><wbr><span class="font-bold text-blue-900">{{
             .name }}</span></div>
         <div class="text-gray-600 text-lg flex-grow pt-2">{{ .description }}</div>
         <div class="flex pt-2 text-sm">

--- a/themes/package-lock.json
+++ b/themes/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
I rebuild the footer to a structure more like AOE website. The about-AOE text is shrunk to match the width of a single page article. I hope this helps for a calmer layout.
The single article view has slightly changed margins/paddings but is overall very similar to the previous version.
The viewport-meta tag and the AOE logo as fav icon was added (copy/paste from AOE website).

Refs: #15