### PR TITLE
fix(theme): add page container for posts page to fix margins

### DIFF
--- a/themes/aoepeople.github.io/layouts/_default/list.html
+++ b/themes/aoepeople.github.io/layouts/_default/list.html
@@ -1,9 +1,12 @@
 {{ define "main" }}
-<div class="pt-8">
-  <h2 class="mt-8 py-4 text-center border-b">Read the AOE Articles</h2>
 
-  {{ range (.GetPage "/posts").Pages }}
-  {{ partial "preview" . }}
-  {{ end }}
+<div class="bg-gradient-gray-light">
+  <div class="container">
+    <h2 class="mt-8 py-4 text-center border-b">Read the AOE Articles</h2>
+
+    {{ range (.GetPage "/posts").Pages }}
+    {{ partial "preview" . }}
+    {{ end }}
+  </div>
 </div>
 {{ end }}


### PR DESCRIPTION
Added container to adjust page margins/paddings like on the other pages

Refs: #47

Preview: https://opensource.aoe.com/_preview-opensource/bugfix/47-posts-page/posts/