### PR TITLE
task(rss): extend RSS feed attributes for blog posts

### DIFF
--- a/themes/aoepeople.github.io/layouts/_default/baseof.html
+++ b/themes/aoepeople.github.io/layouts/_default/baseof.html
@@ -19,6 +19,10 @@
   <noscript><link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/brands.min.css" rel="stylesheet" as="style"></noscript>
   <link rel="preload" href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;200;300;400;500;600;700;800;900&amp;display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;200;300;400;500;600;700;800;900&amp;display=swap" rel="stylesheet" as="style"></noscript>
+
+  {{ range .AlternativeOutputFormats -}}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+  {{ end -}}
 </head>
 
 <body class="text-aoe-gray-dark bg-white text-lg">

--- a/themes/aoepeople.github.io/layouts/posts/rss.xml
+++ b/themes/aoepeople.github.io/layouts/posts/rss.xml
@@ -1,0 +1,48 @@
+{{- $pctx := . -}}
+        {{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
+        {{- $pages := slice -}}
+        {{- if or $.IsHome $.IsSection -}}
+        {{- $pages = $pctx.RegularPages -}}
+        {{- else -}}
+        {{- $pages = $pctx.Pages -}}
+        {{- end -}}
+        {{- $limit := .Site.Config.Services.RSS.Limit -}}
+        {{- if ge $limit 1 -}}
+        {{- $pages = $pages | first $limit -}}
+        {{- end -}}
+        {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+        <link>{{ .Permalink }}</link>
+        <description>Recent {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+        <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+        <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
+        <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
+        <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+        <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+        <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+        {{- with .OutputFormats.Get "RSS" -}}
+        {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+        {{- end -}}
+        {{ range $pages }}
+        <item>
+            <title>{{ .Title }}</title>
+            <link>{{ .Permalink }}</link>
+            <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+            <author>{{ .Params.author }}</author>
+            <guid>{{ .Permalink }}</guid>
+            <description>{{ .Summary | html }}</description>
+            <category>{{ block "tags" . }}{{ with .Site.Params.tags }}{{ delimit . "</category><category>"}}</category><category>{{ end }}{{ with .Params.tags }}{{ delimit . "</category><category>"}}{{ end }}{{ end }}</category>
+            {{ $image := .Page.Resources.GetMatch .Params.image }}
+            {{ with $image }}
+                {{ if strings.HasSuffix .Permalink "svg" }}
+                    <enclosure url="{{ .Permalink }}" type="{{ .MediaType }}"/>
+                {{ else }}
+                    <enclosure url="{{ (.Fill "575x575 q90 smart").Permalink }}" type="{{ .MediaType }}"/>
+                {{ end }}
+            {{ end }}
+        </item>
+        {{ end }}
+    </channel>
+</rss>


### PR DESCRIPTION
RSS feed for blog post extended according to [comment in issue #48](https://github.com/AOEpeople/aoepeople.github.io/issues/48#issuecomment-1119648684)

Refs: #48

RSS-File: https://opensource.aoe.com/_preview-opensource/task/48-Extend-RSS-feed-attributes/posts/index.xml